### PR TITLE
Add Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+language: python
+
+env:
+  global:
+    - CONDA_DEPENDENCIES="pytorch torchvision"
+
+matrix:
+  include:
+    - env: PYTHON_VERSION=2.7
+    - env: PYTHON_VERSION=3.6
+
+install:
+  - git clone --depth 1 git://github.com/astropy/ci-helpers.git
+  - source ci-helpers/travis/setup_conda.sh
+
+script:
+  - python --version
+  - cd Python27/Example/mnist && python train_mnist.py --epochs 2

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,4 +15,4 @@ install:
 
 script:
   - python --version
-  - cd Python27/Example/mnist && python train_mnist.py --epochs 2
+  - cd Python/Example/mnist && python train_mnist.py --epochs 4


### PR DESCRIPTION
At the moment it runs train_mnist.py for 2 epochs on Python 2 and Python 3. Takes ~5-8 minutes for each build.

[astropy/ci-helpers](https://github.com/astropy/ci-helpers) is one of the easiest way to get started with Travis. It basically installs miniconda and create a conda env with the needed dependencies.

AFAIR, to enable Travis on PRs:
* this PR needs to be merged 
* @windows7lover needs to set-up Travis on this project (by going to https://travis-ci.org/profile/windows7lover).

