### PR TITLE
Add Travis badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/windows7lover/RegularizedNonlinearAcceleration.svg?branch=master)](https://travis-ci.org/windows7lover/RegularizedNonlinearAcceleration)
+
 # RegularizedNonlinearAcceleration
 Implementation of the Regularized Nonlinear Acceleration algorithm in Matlab and Python.
 


### PR DESCRIPTION
This adds the Travis badge in the README and makes it more prominent that there is some Continuous Integration on the project.